### PR TITLE
Dynamic Refresh of Screen after Scan

### DIFF
--- a/screen.php
+++ b/screen.php
@@ -139,11 +139,11 @@ require_once __DIR__ . "/incl/db.inc.php";
     </span>
   </div>
     <div id="body" class="content">
-      <span id="event" class="h3">If you see this for more than a couple of seconds, please check if the websocket-server was started</span>
+      <p id="scan-result" class="h2">If you see this for more than a couple of seconds, please check if the websocket-server was started</p>
       <div id="log">
-          <span id="scan-result"></span><br>
-          <span class="h4"> Previous Scans: </span><br>
-          <span id="log-entries" class="subtitle"></span>
+          <p id="event" class="h3"></p><br>
+          <p class="h4 p-t10"> Previous Scans: </p>
+          <span id="log-entries" class="h5"></span>
       </div>
   </div>
 
@@ -183,7 +183,7 @@ if(typeof(EventSource) !== "undefined") {
 
   async function feedbackUpdate() {
         await sleep(2000);
-        document.getElementById('event').textContent = 'Waiting for barcode...';
+        document.getElementById('scan-result').textContent = 'Waiting for barcode...';
       };
 
   source.onopen = function() {
@@ -191,7 +191,7 @@ if(typeof(EventSource) !== "undefined") {
       isFirstStart=false;
       document.body.style.backgroundColor = '#FBFBF8';
       document.getElementById('grocy-sse').textContent = 'Connected';
-      document.getElementById('event').textContent = 'Waiting for barcode...';
+      document.getElementById('scan-result').textContent = 'Waiting for barcode...';
       var http = new XMLHttpRequest();
       http.open("GET", "incl/sse/sse_data.php?getState");
       http.send();
@@ -205,7 +205,7 @@ if(typeof(EventSource) !== "undefined") {
       switch(resultCode) {
         case '0':
         document.body.style.backgroundColor = '#47ac3f';
-        document.getElementById('event').textContent = 'Scan success';
+        document.getElementById('event').textContent = 'Scan Success';
         document.getElementById('scan-result').textContent = he.decode(resultText);
         document.getElementById('beep_success').play();
         document.getElementById('log-entries').innerText = '\r\n' + he.decode(resultText) + document.getElementById('log-entries').innerText;

--- a/screen.php
+++ b/screen.php
@@ -38,6 +38,56 @@ require_once __DIR__ . "/incl/db.inc.php";
   <head>
     <title>Barcode Buddy Screen</title>
     <style>
+      body, html{
+          padding:0;
+          margin:0;
+          position:relative;
+          height:100%
+      }
+      .header {
+          width:100%;
+          background:#ccc;
+          padding:10px;
+          box-sizing:border-box;
+          text-transform: lowercase;
+      }
+      .content{
+          background:#eee;
+          width:100%;
+          padding:10px;
+          height:100%;
+          box-sizing:border-box;
+          padding:10px;
+          text-align: center;
+          align-content: center
+      }
+      .left{
+          width:50%;
+          float:left;
+          background:#bbb;
+          height:100%;
+      }
+      .right{
+          width:50%;
+          float:right;
+          background:#aaa;
+          height:100%;
+      }
+      #left {
+        float: left;
+        width: 70%;
+        align-content: center;
+      }
+      .hdr-left {
+        text-align: center;
+        padding-left: 10px; 
+      }
+      .hdr-right {
+        float: right;
+        width: 30%;
+        text-align: right;
+        padding-right: 10px
+      }
       .bold {
         font: bold 15pt;
       }
@@ -49,7 +99,6 @@ require_once __DIR__ . "/incl/db.inc.php";
       .h1 {
         font: bold 50pt arial;
         margin: auto;
-        padding: 10px;
         text-align: center;
       }
       .h2 {
@@ -68,7 +117,6 @@ require_once __DIR__ . "/incl/db.inc.php";
         font: bold 15pt arial;
         margin: auto;
         padding: 6px;
-        text-align: center;
       }
       .h5 {
         font: bold 10pt arial;
@@ -108,34 +156,28 @@ require_once __DIR__ . "/incl/db.inc.php";
   <script src="./incl/nosleep.min.js"></script>
   <script src="./incl/he.js"></script>
 
-  <div id="right">
-    <div id="status" class="h5">
-      <span>Grocy Status:</span>
-      <span id="grocy-sse">Connecting...</span><br>
-      <span id="mode" ></span><br><br><br>
-    </div>  
+  <div id="header" class="header">
+    <span class="hdr-right h4">
+      Grocy Status: <span id="grocy-sse">Connecting...</span><br>
+    </span>
+      <span id="mode" class="h1 hdr-left"></span>
+    </span>
+  </div>
+    <div id="body" class="content">
+      <span id="event" class="h3">If you see this for more than a couple of seconds, please check if the websocket-server was started</span>
+      <div id="log">
+          <span id="scan-result"></span><br>
+          <span class="h4"> Previous Scans: </span><br>
+          <span id="log-entries" class="subtitle"></span>
+      </div>
   </div>
 
-  <div id="left">
-    <div id="events">
-      <span id="event">If you see this for more than a couple of seconds, please check if the websocket-server was started</span>
-    </div>
-    <div id="log">
-        <span id="scan-result"></span><br>
-        <span class="h4"> Previous Scans: </span><br>
-        <span id="log-entries" class="subtitle"></span>
-    </div>
-  </div>
-  
+
     <audio id="beep_success" muted="muted" src="incl/websocket/beep.ogg"  type="audio/ogg" preload="auto"></audio>
     <audio id="beep_nosuccess" muted="muted" src="incl/websocket/buzzer.ogg"  type="audio/ogg" preload="auto"></audio>
-    <div id="soundbuttondiv">
-<button class="sound" onclick="toggleSound()" id="soundbutton"><img id="muteimg" src="incl/img/mute.svg" alt="Toggle sound and wakelock"></button>
-</div>
-    
-     
-    
-    
+  <div id="soundbuttondiv">
+    <button class="sound" onclick="toggleSound()" id="soundbutton"><img id="muteimg" src="incl/img/mute.svg" alt="Toggle sound and wakelock"></button>
+  </div>
     
     <script>
 
@@ -207,7 +249,7 @@ if(typeof(EventSource) !== "undefined") {
         document.getElementById('beep_nosuccess').play();
           break;
         case '4':
-        document.getElementById('mode').textContent = 'Current Mode: '+resultText;
+        document.getElementById('mode').textContent = resultText;
           break;
         case 'E':
         document.body.style.backgroundColor = '#f9868b';

--- a/screen.php
+++ b/screen.php
@@ -231,14 +231,14 @@ if(typeof(EventSource) !== "undefined") {
         document.getElementById('mode').textContent = resultText;
           break;
         case 'E':
-        document.body.style.backgroundColor = '#CC0605';
+        content.style.backgroundColor = '#CC0605';
         document.getElementById('title').textContent = 'Error';
         document.getElementById('subtitle').textContent = resultText;
           break;
       }
   };
 } else {
-        document.body.style.backgroundColor = '#f9868b';
+        content.style.backgroundColor = '#f9868b';
         document.getElementById('title').textContent = 'Disconnected';
         document.getElementById('subtitle').textContent = 'Sorry, your browser does not support server-sent events';
 }

--- a/screen.php
+++ b/screen.php
@@ -127,7 +127,7 @@ require_once __DIR__ . "/incl/db.inc.php";
     </style>
 
   </head>
-  <body bgcolor="#f6ff94">
+  <body>
   <script src="./incl/nosleep.min.js"></script>
   <script src="./incl/he.js"></script>
 
@@ -138,11 +138,11 @@ require_once __DIR__ . "/incl/db.inc.php";
       <span id="mode" class="h1 hdr-left"></span>
     </span>
   </div>
-    <div id="body" class="content">
-      <p id="scan-result" class="h2">If you see this for more than a couple of seconds, please check if the websocket-server was started</p>
+    <div id="content" class="content">
+      <p id="scan-result" class="h2">If you see this for more than a couple of seconds, please check if the that Grocy is available</p>
       <div id="log">
           <p id="event" class="h3"></p><br>
-          <p class="h4 p-t10"> Previous Scans: </p>
+          <p class="h4 p-t10"> previous scans: </p>
           <span id="log-entries" class="h5"></span>
       </div>
   </div>
@@ -183,8 +183,8 @@ if(typeof(EventSource) !== "undefined") {
 
   async function resetScan() {
     await sleep(2000);
-    document.body.style.backgroundColor = '#f6ff94';
-    document.getElementById('scan-result').textContent = 'Waiting for barcode...';
+    content.style.backgroundColor = '#eee';
+    document.getElementById('scan-result').textContent = 'waiting for barcode...';
     document.getElementById('event').textContent = '';
   };
 
@@ -192,8 +192,8 @@ if(typeof(EventSource) !== "undefined") {
       return new Promise(resolve => setTimeout(resolve, ms));
   };
 
-  function resultScan(message, text, sound) {
-    document.body.style.backgroundColor = '#47ac3f';
+  function resultScan(color, message, text, sound) {
+    content.style.backgroundColor = color;
     document.getElementById('event').textContent = message;
     document.getElementById('scan-result').textContent = text;
     document.getElementById(sound).play();
@@ -205,9 +205,8 @@ if(typeof(EventSource) !== "undefined") {
   source.onopen = function() {
     if (isFirstStart) {
       isFirstStart=false;
-      document.body.style.backgroundColor = '#FBFBF8';
       document.getElementById('grocy-sse').textContent = 'Connected';
-      document.getElementById('scan-result').textContent = 'Waiting for barcode...';
+      document.getElementById('scan-result').textContent = 'waiting for barcode...';
       var http = new XMLHttpRequest();
       http.open("GET", "incl/sse/sse_data.php?getState");
       http.send();
@@ -220,20 +219,19 @@ if(typeof(EventSource) !== "undefined") {
             var resultText = resultJson.data.substring(1);  
       switch(resultCode) {
         case '0':
-        resultScan("Scan Succeeded", he.decode(resultText), "beep_success");
+        resultScan("#33a532", "Scan Succeeded", he.decode(resultText), "beep_success");
           break;
         case '1':
-        resultScan("Barcode Looked Up",he.decode(resultText), "beep_success" )
+        resultScan("#33a532", "Barcode Looked Up", he.decode(resultText), "beep_success");
           break;
         case '2':
-        resultScan("Unknown Barcode", resultText, "beep_nosuccess")
-
+        resultScan("#F7B500", "Unknown Barcode", resultText, "beep_nosuccess");
           break;
         case '4':
         document.getElementById('mode').textContent = resultText;
           break;
         case 'E':
-        document.body.style.backgroundColor = '#f9868b';
+        document.body.style.backgroundColor = '#CC0605';
         document.getElementById('title').textContent = 'Error';
         document.getElementById('subtitle').textContent = resultText;
           break;

--- a/screen.php
+++ b/screen.php
@@ -183,13 +183,24 @@ if(typeof(EventSource) !== "undefined") {
 
   async function resetScan() {
     await sleep(2000);
+    document.body.style.backgroundColor = '#f6ff94';
     document.getElementById('scan-result').textContent = 'Waiting for barcode...';
     document.getElementById('event').textContent = '';
   };
 
   function sleep(ms) {
       return new Promise(resolve => setTimeout(resolve, ms));
-  }
+  };
+
+  function resultScan(message, text, sound) {
+    document.body.style.backgroundColor = '#47ac3f';
+    document.getElementById('event').textContent = message;
+    document.getElementById('scan-result').textContent = text;
+    document.getElementById(sound).play();
+    document.getElementById('log-entries').innerText = '\r\n' + text + document.getElementById('log-entries').innerText;
+    resetScan();
+
+  };
 
   source.onopen = function() {
     if (isFirstStart) {
@@ -209,24 +220,14 @@ if(typeof(EventSource) !== "undefined") {
             var resultText = resultJson.data.substring(1);  
       switch(resultCode) {
         case '0':
-        document.body.style.backgroundColor = '#47ac3f';
-        document.getElementById('event').textContent = 'Scan Success';
-        document.getElementById('scan-result').textContent = he.decode(resultText);
-        document.getElementById('beep_success').play();
-        document.getElementById('log-entries').innerText = '\r\n' + he.decode(resultText) + document.getElementById('log-entries').innerText;
-        resetScan()
+        resultScan("Scan Succeeded", he.decode(resultText), "beep_success");
           break;
         case '1':
-        document.body.style.backgroundColor = '#a2ff9b';
-        document.getElementById('title').textContent = 'Barcode looked up';
-        document.getElementById('subtitle').textContent = he.decode(resultText);
-        document.getElementById('beep_success').play();
+        resultScan("Barcode Looked Up",he.decode(resultText), "beep_success" )
           break;
         case '2':
-        document.body.style.backgroundColor = '#eaff8a';
-        document.getElementById('title').textContent = 'Unknown barcode';
-        document.getElementById('subtitle').textContent = resultText;
-        document.getElementById('beep_nosuccess').play();
+        resultScan("Unknown Barcode", resultText, "beep_nosuccess")
+
           break;
         case '4':
         document.getElementById('mode').textContent = resultText;

--- a/screen.php
+++ b/screen.php
@@ -38,19 +38,39 @@ require_once __DIR__ . "/incl/db.inc.php";
   <head>
     <title>Barcode Buddy Screen</title>
     <style>
-
+      .bold {
+        font: bold 15pt;
+      }
       #soundbuttondiv {
         position: fixed;
         bottom: 10px;
         right: 10px;
       }
-      #title {
+      .h1 {
         font: bold 50pt arial;
         margin: auto;
         padding: 10px;
         text-align: center;
       }
-      #mode {
+      .h2 {
+        font: bold 40pt arial;
+        margin: auto;
+        padding: 10px;
+        text-align: center;
+      }
+      .h3 {
+        font: bold 30pt arial;
+        margin: auto;
+        padding: 10px;
+        text-align: center;
+      }
+      .h4 {
+        font: bold 15pt arial;
+        margin: auto;
+        padding: 6px;
+        text-align: center;
+      }
+      .h5 {
         font: bold 10pt arial;
         margin: auto;
         text-align: center;
@@ -87,25 +107,33 @@ require_once __DIR__ . "/incl/db.inc.php";
   <body bgcolor="#f6ff94">
   <script src="./incl/nosleep.min.js"></script>
   <script src="./incl/he.js"></script>
-  <div id="status">
-    <span id="grocy-sse">Connecting...</span>
-    <div id="mode"></div><br><br><br>
-  </div>  
-  <div id="events">
-    <span id="event">If you see this for more than a couple of seconds, please check if the websocket-server was started</span>
-  </div>
-  <div id="log">
-      <span class="title"> Previous Scans: </span>
-      <span id="log-entries" class="subtitle"></span>
+
+  <div id="right">
+    <div id="status" class="h5">
+      <span>Grocy Status:</span>
+      <span id="grocy-sse">Connecting...</span><br>
+      <span id="mode" ></span><br><br><br>
+    </div>  
   </div>
 
+  <div id="left">
+    <div id="events">
+      <span id="event">If you see this for more than a couple of seconds, please check if the websocket-server was started</span>
+    </div>
+    <div id="log">
+        <span id="scan-result"></span><br>
+        <span class="h4"> Previous Scans: </span><br>
+        <span id="log-entries" class="subtitle"></span>
+    </div>
+  </div>
+  
     <audio id="beep_success" muted="muted" src="incl/websocket/beep.ogg"  type="audio/ogg" preload="auto"></audio>
     <audio id="beep_nosuccess" muted="muted" src="incl/websocket/buzzer.ogg"  type="audio/ogg" preload="auto"></audio>
     <div id="soundbuttondiv">
 <button class="sound" onclick="toggleSound()" id="soundbutton"><img id="muteimg" src="incl/img/mute.svg" alt="Toggle sound and wakelock"></button>
 </div>
     
-    
+     
     
     
     
@@ -136,6 +164,10 @@ require_once __DIR__ . "/incl/db.inc.php";
 if(typeof(EventSource) !== "undefined") {
   var source = new EventSource("incl/sse/sse_data.php");
 
+  async function feedbackUpdate() {
+        await sleep(2000);
+        document.getElementById('event').textContent = 'Waiting for barcode...';
+      };
 
   source.onopen = function() {
     if (isFirstStart) {
@@ -156,9 +188,11 @@ if(typeof(EventSource) !== "undefined") {
       switch(resultCode) {
         case '0':
         document.body.style.backgroundColor = '#47ac3f';
-        document.getElementById('title').textContent = 'Scan success';
-        document.getElementById('subtitle').textContent = he.decode(resultText);
+        document.getElementById('event').textContent = 'Scan success';
+        document.getElementById('scan-result').textContent = he.decode(resultText);
         document.getElementById('beep_success').play();
+        document.getElementById('log-entries').innerText = '\r\n' + he.decode(resultText) + document.getElementById('log-entries').innerText;
+
           break;
         case '1':
         document.body.style.backgroundColor = '#a2ff9b';

--- a/screen.php
+++ b/screen.php
@@ -87,16 +87,28 @@ require_once __DIR__ . "/incl/db.inc.php";
   <body bgcolor="#f6ff94">
   <script src="./incl/nosleep.min.js"></script>
   <script src="./incl/he.js"></script>
-    
-    <div id="title">Connecting...</div><br>
+  <div id="status">
+    <span id="grocy-sse">Connecting...</span>
     <div id="mode"></div><br><br><br>
-    <div id="subtitle">If you see this for more than a couple of seconds, please check if the websocket-server was started</div>
+  </div>  
+  <div id="events">
+    <span id="event">If you see this for more than a couple of seconds, please check if the websocket-server was started</span>
+  </div>
+  <div id="log">
+      <span class="title"> Previous Scans: </span>
+      <span id="log-entries" class="subtitle"></span>
+  </div>
 
     <audio id="beep_success" muted="muted" src="incl/websocket/beep.ogg"  type="audio/ogg" preload="auto"></audio>
     <audio id="beep_nosuccess" muted="muted" src="incl/websocket/buzzer.ogg"  type="audio/ogg" preload="auto"></audio>
     <div id="soundbuttondiv">
 <button class="sound" onclick="toggleSound()" id="soundbutton"><img id="muteimg" src="incl/img/mute.svg" alt="Toggle sound and wakelock"></button>
 </div>
+    
+    
+    
+    
+    
     <script>
 
       var noSleep          = new NoSleep();
@@ -128,9 +140,9 @@ if(typeof(EventSource) !== "undefined") {
   source.onopen = function() {
     if (isFirstStart) {
       isFirstStart=false;
-      document.body.style.backgroundColor = '#b9ffad';
-      document.getElementById('title').textContent = 'Connected';
-      document.getElementById('subtitle').textContent = 'Waiting for barcode...';
+      document.body.style.backgroundColor = '#FBFBF8';
+      document.getElementById('grocy-sse').textContent = 'Connected';
+      document.getElementById('event').textContent = 'Waiting for barcode...';
       var http = new XMLHttpRequest();
       http.open("GET", "incl/sse/sse_data.php?getState");
       http.send();

--- a/screen.php
+++ b/screen.php
@@ -61,23 +61,6 @@ require_once __DIR__ . "/incl/db.inc.php";
           text-align: center;
           align-content: center
       }
-      .left{
-          width:50%;
-          float:left;
-          background:#bbb;
-          height:100%;
-      }
-      .right{
-          width:50%;
-          float:right;
-          background:#aaa;
-          height:100%;
-      }
-      #left {
-        float: left;
-        width: 70%;
-        align-content: center;
-      }
       .hdr-left {
         text-align: center;
         padding-left: 10px; 
@@ -88,9 +71,7 @@ require_once __DIR__ . "/incl/db.inc.php";
         text-align: right;
         padding-right: 10px
       }
-      .bold {
-        font: bold 15pt;
-      }
+
       #soundbuttondiv {
         position: fixed;
         bottom: 10px;
@@ -121,12 +102,6 @@ require_once __DIR__ . "/incl/db.inc.php";
       .h5 {
         font: bold 10pt arial;
         margin: auto;
-        text-align: center;
-      }
-      #subtitle {
-        font: bold 20pt arial;
-        margin: auto;
-        padding: 10px;
         text-align: center;
       }
       .sound {

--- a/screen.php
+++ b/screen.php
@@ -181,10 +181,15 @@ require_once __DIR__ . "/incl/db.inc.php";
 if(typeof(EventSource) !== "undefined") {
   var source = new EventSource("incl/sse/sse_data.php");
 
-  async function feedbackUpdate() {
-        await sleep(2000);
-        document.getElementById('scan-result').textContent = 'Waiting for barcode...';
-      };
+  async function resetScan() {
+    await sleep(2000);
+    document.getElementById('scan-result').textContent = 'Waiting for barcode...';
+    document.getElementById('event').textContent = '';
+  };
+
+  function sleep(ms) {
+      return new Promise(resolve => setTimeout(resolve, ms));
+  }
 
   source.onopen = function() {
     if (isFirstStart) {
@@ -209,7 +214,7 @@ if(typeof(EventSource) !== "undefined") {
         document.getElementById('scan-result').textContent = he.decode(resultText);
         document.getElementById('beep_success').play();
         document.getElementById('log-entries').innerText = '\r\n' + he.decode(resultText) + document.getElementById('log-entries').innerText;
-
+        resetScan()
           break;
         case '1':
         document.body.style.backgroundColor = '#a2ff9b';


### PR DESCRIPTION
The WIP PR was a mess to get cleaned up so I started over.

My overall goal for the Screen page is to keep my device open when scanning things and get the feedback I need from it while scanning in shopping purchases.  Therefore I've approached it as much of a 10 foot view as possible.  I want to be able to see what is happening without having to squint or scroll.

To achieve this:

1: I've added more styling to create a header that indicates Grocy status and what mode bbuddy is currently in.  This means I've added several new CSS classes and reconfigured the div IDs for existing divs to both apply styling and text changes.
2: I've changed the background to a neutral color so it's easier to see when the screen has changed.  I'm using US Stop light hex codes for  Red / Green / Yellow.
3: From a purely stylistic approach, I've lower cased all text.  I can revert that, but I think it's easier on the eye with the chosen font.

In terms of code readability:

I refactored the `case` statement to be more DRY by adding a function that's called by each case so that you need only pass params through, not repeating each elemental update.

I've two new functions: `resultScan` and `resetScan`.  `resultScan` handles updating the necessary elements when a code is scanned and `resetScan` is called by `resultScan` to reset the page after 2000ms.

![image](https://user-images.githubusercontent.com/49296333/78082148-49d62300-7380-11ea-832b-9e0db950a4f2.png)


## Other stuff:
Once this is 👍, I have another PR that I'm going to send over that pulls the JS and CSS out for easier maintainability.

After that, I'm currently working on adding "mode" buttons so that you can tap an icon to change the mode right from the screen.

I'm also going to send over a PR that ties my input variant 3 script to `screen.php'.  I'm adding a scanner status endpoint to bbuddy and will extend the current variant 3 script to register and deregister barcode scanner availability.