### PR TITLE
Allow using environment variables in bash script

### DIFF
--- a/example/grabInput.sh
+++ b/example/grabInput.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 
-SCRIPT_LOCATION="/var/www/html/barcodebuddy/index.php"
-SERVER_ADDRESS="https://your.bbuddy.url/index.php"
+SCRIPT_LOCATION="${SCRIPT_LOCATION:="/var/www/html/barcodebuddy/index.php"}"
+SERVER_ADDRESS="${SERVER:ADDRESS:="https://your.bbuddy.url/index.php"}"
 
-USE_CURL=false
-WWW_USER="www-data"
-IS_DOCKER=false
+USE_CURL="${USE_CURL:="false"}"
+WWW_USER="${WWW_USER:="www-data"}"
+IS_DOCKER="${IS_DOCKER:="false"}"
 
 declare -A CODE_MAP_CHAR=( ["(KEY_0)"]="0" \
     ["(KEY_1)"]="1" \


### PR DESCRIPTION
This is just a really quick change to avoid having to manually adjust the script in order to use it.
This allows me to stay on the safe side if the script is updated and I can easily run it as a systemd service like this:

```
[Unit]
Description=Grab barcode reader input for barcode buddy

[Service]
User=root
ExecStart=/srv/http/barcodebuddy/example/grabInput.sh /dev/input/event18
Environment=SCRIPT_LOCATION=/srv/http/barcodebuddy/index.php
Environment=WWW_USER=http

[Install]
WantedBy=multi-user.target
```