### PR TITLE
Limit connection retries on net::ERR_CONNECTION_REFUSED

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,0 @@
-debug
-data/barcodebuddy.db
-data/config.php
-data/users.db
-**/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ debug
 data/barcodebuddy.db
 data/config.php
 data/users.db
+**/.DS_Store

--- a/screen.php
+++ b/screen.php
@@ -221,7 +221,26 @@ if(typeof(EventSource) !== "undefined") {
   var source = new EventSource("incl/sse/sse_data.php");
 
   var currentScanId = 0;
+  var connectFailCounter = 0;
 
+  source.addEventListener("error", function(event) {
+    switch (event.target.readyState) {
+      case EventSource.CONNECTING:
+        document.getElementById('grocy-sse').textContent = 'Reconnecting...';
+        // console.log('Reconnecting...');
+        connectFailCounter ++
+          if (connectFailCounter == 500) {
+            source.close();
+            document.getElementById('grocy-sse').textContent = 'Unavailable';
+            document.getElementById('scan-result').textContent = 'Sorry, the server is offline';
+          }
+        break;
+      case EventSource.CLOSED:
+        console.log('Connection failed (CLOSED)');
+        break;
+    }
+  }, false);
+  
   async function resetScan(scanId) {
     await sleep(3000);
     if (currentScanId == scanId) {


### PR DESCRIPTION
It looks like screen.php tries to establish a connection every 1ms or so if it doesn't find the server any more.

To reproduce:
- start a bbuddy container
- browse to screen.php, let it sit on "waiting for barcode"
- kill the container
- watch the error counter as it revs up in the browser console
- find how fast your js interpreter is by comparing the numbers with your friends :)

Those connection add up quickly, and while it's not a big deal on a laptop it can bring a RPi on her knees in minutes.

![Schermata 2020-04-15 alle 18 17 13](https://user-images.githubusercontent.com/63677902/79378741-25706e00-7f5e-11ea-95ff-03ff33acf82c.png)

Not sure if/how you want to deal with it, but my take is to add a listener to the event source and limit the connections retries to 500 (plenty if it's just a glitch on the server side) then close the connection with an error message

![Schermata 2020-04-15 alle 19 43 35](https://user-images.githubusercontent.com/63677902/79379054-91eb6d00-7f5e-11ea-98e3-a6e36a80ee34.png)

Not a big fan of websockets btw, maybe there are better ways to fix it...