### PR TITLE
Palm globals2

### DIFF
--- a/.github/workflows/baseline.xml
+++ b/.github/workflows/baseline.xml
@@ -51,6 +51,9 @@
     </UndefinedDocblockClass>
   </file>
   <file src="incl/authentication/authentication.inc.php">
+    <InvalidGlobal occurrences="1">
+      <code>global $CONFIG;</code>
+    </InvalidGlobal>
     <UndefinedClass occurrences="3">
       <code>\Delight\Db\PdoDsn</code>
       <code>\Delight\Auth\Auth</code>
@@ -69,6 +72,9 @@
     <ForbiddenCode occurrences="1">
       <code>var_dump($variable)</code>
     </ForbiddenCode>
+    <InvalidGlobal occurrences="1">
+      <code>global $CONFIG;</code>
+    </InvalidGlobal>
     <InvalidOperand occurrences="1">
       <code>$subnetMask</code>
     </InvalidOperand>
@@ -107,6 +113,9 @@
     </UndefinedFunction>
   </file>
   <file src="incl/db.inc.php">
+    <DeprecatedMethod occurrences="1">
+      <code>BBConfig::getInstance()</code>
+    </DeprecatedMethod>
     <PossiblyNullArgument occurrences="4">
       <code>$config["BARCODE_C"]</code>
       <code>$config["BARCODE_O"]</code>
@@ -202,6 +211,12 @@
       <code>\Delight\Auth\UnknownUsernameException</code>
       <code>\Delight\Auth\Role</code>
     </UndefinedClass>
+  </file>
+  <file src="menu/settings.php">
+    <PossiblyNullArgument occurrences="2">
+      <code>$config["GROCY_API_URL"]</code>
+      <code>$config["GROCY_API_KEY"]</code>
+    </PossiblyNullArgument>
   </file>
   <file src="wsserver.php">
     <UndefinedClass occurrences="2">

--- a/.github/workflows/baseline.xml
+++ b/.github/workflows/baseline.xml
@@ -88,7 +88,7 @@
       <code>$subnet</code>
       <code>$subnet</code>
     </MissingClosureParamType>
-    <UndefinedConstant occurrences="17">
+    <UndefinedConstant occurrences="18">
       <code>PORT_WEBSOCKET_SERVER</code>
       <code>DATABASE_PATH</code>
       <code>CURL_TIMEOUT_S</code>

--- a/.github/workflows/baseline.xml
+++ b/.github/workflows/baseline.xml
@@ -51,9 +51,6 @@
     </UndefinedDocblockClass>
   </file>
   <file src="incl/authentication/authentication.inc.php">
-    <InvalidGlobal occurrences="1">
-      <code>global $CONFIG;</code>
-    </InvalidGlobal>
     <UndefinedClass occurrences="3">
       <code>\Delight\Db\PdoDsn</code>
       <code>\Delight\Auth\Auth</code>
@@ -72,9 +69,6 @@
     <ForbiddenCode occurrences="1">
       <code>var_dump($variable)</code>
     </ForbiddenCode>
-    <InvalidGlobal occurrences="1">
-      <code>global $CONFIG;</code>
-    </InvalidGlobal>
     <InvalidOperand occurrences="1">
       <code>$subnetMask</code>
     </InvalidOperand>
@@ -208,12 +202,6 @@
       <code>\Delight\Auth\UnknownUsernameException</code>
       <code>\Delight\Auth\Role</code>
     </UndefinedClass>
-  </file>
-  <file src="menu/settings.php">
-    <PossiblyNullArgument occurrences="2">
-      <code>$config["GROCY_API_URL"]</code>
-      <code>$config["GROCY_API_KEY"]</code>
-    </PossiblyNullArgument>
   </file>
   <file src="wsserver.php">
     <UndefinedClass occurrences="2">

--- a/.github/workflows/baseline.xml
+++ b/.github/workflows/baseline.xml
@@ -113,9 +113,6 @@
     </UndefinedFunction>
   </file>
   <file src="incl/db.inc.php">
-    <DeprecatedMethod occurrences="1">
-      <code>BBConfig::getInstance()</code>
-    </DeprecatedMethod>
     <PossiblyNullArgument occurrences="4">
       <code>$config["BARCODE_C"]</code>
       <code>$config["BARCODE_O"]</code>

--- a/.github/workflows/baseline.xml
+++ b/.github/workflows/baseline.xml
@@ -106,6 +106,7 @@
       <code>TRUSTED_PROXIES</code>
       <code>CONFIG_PATH</code>
       <code>AUTHDB_PATH</code>
+      <code>SEARCH_ENGINE</code>
     </UndefinedConstant>
     <UndefinedFunction occurrences="2">
       <code>createConfigPhp($configPath)</code>

--- a/.github/workflows/psalm.xml
+++ b/.github/workflows/psalm.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0"?>
 <psalm xmlns="https://getpsalm.org/schema/config"
        errorBaseline=".github/workflows/baseline.xml">
-<issueHandlers>
-  <MissingParamType errorLevel="suppress" />
-  <MissingReturnType  errorLevel="suppress" />
-  <MissingClosureReturnType errorLevel="suppress" />
-  <MissingPropertyType errorLevel="suppress" />
-  <TypeDoesNotContainType errorLevel="info" />
-  <InvalidDocblock errorLevel="info" />
-</issueHandlers>
+    <issueHandlers>
+        <MissingParamType errorLevel="suppress" />
+        <MissingReturnType  errorLevel="suppress" />
+        <MissingClosureReturnType errorLevel="suppress" />
+        <MissingPropertyType errorLevel="suppress" />
+        <TypeDoesNotContainType errorLevel="info" />
+        <InvalidDocblock errorLevel="info" />
+    </issueHandlers>
     <projectFiles>
         <directory name="."/>
         <ignoreFiles>
@@ -17,7 +17,4 @@
             <directory name="./vendor"/>
         </ignoreFiles>
     </projectFiles>
-    <globals>
-        <var name="BBCONFIG" type="array" />
-    </globals>
 </psalm>


### PR DESCRIPTION
As discussed in #82, adjusted Psalm configs to complain more about the BBCONFIG global variable if necessary. Also added an exclusion for the remaining global variable content (`$CONFIG`)