### PR TITLE
Refactor Provider Lookups for Scalability

### DIFF
--- a/config-dist.php
+++ b/config-dist.php
@@ -102,7 +102,9 @@ const OVERRIDDEN_USER_CONFIG       = array(
                                          //"USE_GROCY_QU_FACTOR"         => "0",
                                          //"SHOW_STOCK_ON_SCAN"          => "0",
                                          // "LOOKUP_USE_OFF"             => "1",
-                                         // "LOOKUP_USE_UPC"             => "1"
+                                         // "LOOKUP_USE_UPC"             => "1",
+                                         // "LOOKUP_USE_UPC_DATABASE"    => "0",
+                                         // "LOOKUP_UPC_DATABASE_KEY"    => null
                                          );
 
 

--- a/config-dist.php
+++ b/config-dist.php
@@ -103,6 +103,7 @@ const OVERRIDDEN_USER_CONFIG       = array(
                                          //"SHOW_STOCK_ON_SCAN"          => "0",
                                          // "LOOKUP_USE_OFF"             => "1",
                                          // "LOOKUP_USE_UPC"             => "1",
+                                         // "LOOKUP_USE_JUMBO"           => "0",
                                          // "LOOKUP_USE_UPC_DATABASE"    => "0",
                                          // "LOOKUP_UPC_DATABASE_KEY"    => null
                                          );

--- a/incl/api.inc.php
+++ b/incl/api.inc.php
@@ -196,6 +196,7 @@ class API {
         }
 
         $curl = new CurlGenerator($apiurl);
+        $result = null;
         try {
             $result = $curl->execute(true);
         } catch (Exception $e) {

--- a/incl/api.inc.php
+++ b/incl/api.inc.php
@@ -195,8 +195,8 @@ class API {
             $apiurl = API_PRODUCTS . "/" . $productId;
         }
 
+        $result = null;  // Assure assignment in event curl throws exception.
         $curl = new CurlGenerator($apiurl);
-        $result = null;
         try {
             $result = $curl->execute(true);
         } catch (Exception $e) {

--- a/incl/db.inc.php
+++ b/incl/db.inc.php
@@ -78,7 +78,9 @@ class DatabaseConnection {
         "LOOKUP_USE_OFF"         => "1",
         "LOOKUP_USE_UPC"         => "1",
         "LOOKUP_USE_JUMBO"       => "0",
-        "LOOKUP_UPC_DATABASE_KEY"=> "0");
+        "LOOKUP_USE_UPC_DATABASE"=> "0",
+        "LOOKUP_UPC_DATABASE_KEY"=> null);
+
 
     const DB_INT_VALUES = array("REVERT_TIME");
 

--- a/incl/db.inc.php
+++ b/incl/db.inc.php
@@ -77,7 +77,8 @@ class DatabaseConnection {
         "SHOW_STOCK_ON_SCAN"     => "0",
         "LOOKUP_USE_OFF"         => "1",
         "LOOKUP_USE_UPC"         => "1",
-        "LOOKUP_USE_JUMBO"       => "0");
+        "LOOKUP_USE_JUMBO"       => "0",
+        "LOOKUP_UPC_DATABASE_KEY"=> "0");
 
     const DB_INT_VALUES = array("REVERT_TIME");
 

--- a/incl/lookupProviders/BarcodeLookup.class.php
+++ b/incl/lookupProviders/BarcodeLookup.class.php
@@ -21,24 +21,24 @@ require_once __DIR__ . "/../config.inc.php";
 
 class BarcodeLookup {
 
+    private static $providers = array(
+        "ProviderOpenFoodFacts",
+        "ProviderUpcDb",
+        "ProviderJumbo",
+        "ProviderUpcDatabase"
+    );
+
     /**
      * Look up a barcode using providers
      * @param string $barcode Input barcode
      * @return string Returns product name or "N/A" if not found
      */
     public static function lookUp($barcode) {
-
-        $result = (new ProviderOpenFoodFacts())->lookupBarcode($barcode);
-        if ($result != null)
-            return $result;
-
-        $result = (new ProviderUpcDb())->lookupBarcode($barcode);
-        if ($result != null)
-            return $result;
-
-        $result = (new ProviderJumbo())->lookupBarcode($barcode);
-        if ($result != null)
-            return $result;
+        foreach (BarcodeLookup::$providers as &$provider) {
+            $result = (new $provider())->lookupBarcode($barcode);
+            if ($result != null)
+                return $result;
+        }
 
         return "N/A";
     }

--- a/incl/lookupProviders/LookupProvider.class.php
+++ b/incl/lookupProviders/LookupProvider.class.php
@@ -18,6 +18,7 @@
 require_once __DIR__ . "/ProviderOpenFoodFacts.php";
 require_once __DIR__ . "/ProviderUpcDb.php";
 require_once __DIR__ . "/ProviderJumbo.php";
+require_once __DIR__ . "/ProviderUpcDatabase.php";
 
 class LookupProvider {
 

--- a/incl/lookupProviders/ProviderOpenFoodFacts.php
+++ b/incl/lookupProviders/ProviderOpenFoodFacts.php
@@ -19,7 +19,6 @@ require_once __DIR__ . "/../api.inc.php";
 
 class ProviderOpenFoodFacts extends LookupProvider {
 
-
     function __construct($apiKey = null) {
         parent::__construct($apiKey);
         $this->providerName      = "OpenFoodFacts";

--- a/incl/lookupProviders/ProviderUpcDatabase.php
+++ b/incl/lookupProviders/ProviderUpcDatabase.php
@@ -35,18 +35,18 @@ class ProviderUpcDatabase extends LookupProvider {
     public function lookupBarcode($barcode) {
         $upcdb_key = BBConfig::getInstance()['LOOKUP_UPC_DATABASE_KEY'];
         if (!$this->isProviderEnabled() || !$upcdb_key)
-            return null;
+            return "NOT ENABLED " . $upcdb_key;
 
         $url    = "https://api.upcdatabase.org/product/" . $barcode . "?apikey=" . $upcdb_key;
         $result = $this->execute($url);
         if (!isset($result["success"]) || !$result["success"] || (!isset($result["description"]) && !isset($result["title"])))
-            return null;
+            return "MISSING FIELDS " . $url;
 
         if (!empty($result["title"])) {
             return sanitizeString($result["title"]);
         } else if (!empty($result["description"])) {
             return sanitizeString($result["description"]);
         }
-        return null;
+        return "NO TITLE OR DESC " . $url;
     }
 }

--- a/incl/lookupProviders/ProviderUpcDatabase.php
+++ b/incl/lookupProviders/ProviderUpcDatabase.php
@@ -23,7 +23,7 @@ class ProviderUpcDatabase extends LookupProvider {
     function __construct($apiKey = null) {
         parent::__construct($apiKey);
         $this->providerName       = "UPC Database";
-        $this->providerConfigKey  = "LOOKUP_UPC_DATABASE_KEY";
+        $this->providerConfigKey  = "LOOKUP_USE_UPC_DATABASE";
         $this->ignoredResultCodes = array();
     }
 
@@ -33,8 +33,8 @@ class ProviderUpcDatabase extends LookupProvider {
      * @return null|string         Name of product, null if none found
      */
     public function lookupBarcode($barcode) {
-        $upcdb_key = $this->isProviderEnabled();
-        if (!$upcdb_key)
+        $upcdb_key = BBConfig::getInstance()['LOOKUP_UPC_DATABASE_KEY'];
+        if (!$this->isProviderEnabled() || !$upcdb_key)
             return null;
 
         $url    = "https://api.upcdatabase.org/product/" . $barcode . "?apikey=" . $upcdb_key;

--- a/incl/lookupProviders/ProviderUpcDatabase.php
+++ b/incl/lookupProviders/ProviderUpcDatabase.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Barcode Buddy for Grocy
+ *
+ * PHP version 7
+ *
+ * LICENSE: This source file is subject to version 3.0 of the GNU General
+ * Public License v3.0 that is attached to this project.
+ *
+ * @author     Marc Ole Bulling
+ * @copyright  2019 Marc Ole Bulling
+ * @license    https://www.gnu.org/licenses/gpl-3.0.en.html  GNU GPL v3.0
+ * @since      File available since Release 1.5
+ */
+
+
+require_once __DIR__ . "/../api.inc.php";
+
+class ProviderUpcDatabase extends LookupProvider {
+
+
+    function __construct($apiKey = null) {
+        parent::__construct($apiKey);
+        $this->providerName       = "UPC Database";
+        $this->providerConfigKey  = "LOOKUP_UPC_DATABASE_KEY";
+        $this->ignoredResultCodes = array();
+    }
+
+    /**
+     * Looks up a barcode
+     * @param string $barcode The barcode to lookup
+     * @return null|string         Name of product, null if none found
+     */
+    public function lookupBarcode($barcode) {
+        $upcdb_key = $this->isProviderEnabled();
+        if (!$upcdb_key)
+            return null;
+
+        $url    = "https://api.upcdatabase.org/product/" . $barcode . "?apikey=" . $upcdb_key;
+        $result = $this->execute($url);
+        if (!isset($result["success"]) || !$result["success"] || (!isset($result["description"]) && !isset($result["title"])))
+            return null;
+
+        if (!empty($result["title"])) {
+            return sanitizeString($result["title"]);
+        } else if (!empty($result["description"])) {
+            return sanitizeString($result["description"]);
+        }
+        return null;
+    }
+}

--- a/incl/lookupProviders/ProviderUpcDatabase.php
+++ b/incl/lookupProviders/ProviderUpcDatabase.php
@@ -35,18 +35,19 @@ class ProviderUpcDatabase extends LookupProvider {
     public function lookupBarcode($barcode) {
         $upcdb_key = BBConfig::getInstance()['LOOKUP_UPC_DATABASE_KEY'];
         if (!$this->isProviderEnabled() || !$upcdb_key)
-            return "NOT ENABLED " . $upcdb_key;
+            return null;
 
-        $url    = "https://api.upcdatabase.org/product/" . $barcode . "?apikey=" . $upcdb_key;
+        $paddedBarcode = str_pad($barcode, 13, "0", STR_PAD_LEFT);
+        $url = "https://api.upcdatabase.org/product/" . $paddedBarcode . "?apikey=" . $upcdb_key;
         $result = $this->execute($url);
         if (!isset($result["success"]) || !$result["success"] || (!isset($result["description"]) && !isset($result["title"])))
-            return "MISSING FIELDS " . $url;
+            return null;
 
         if (!empty($result["title"])) {
             return sanitizeString($result["title"]);
         } else if (!empty($result["description"])) {
             return sanitizeString($result["description"]);
         }
-        return "NO TITLE OR DESC " . $url;
+        return null;
     }
 }

--- a/incl/processing.inc.php
+++ b/incl/processing.inc.php
@@ -448,14 +448,16 @@ function getQuantityForBarcode($barcode, $isConsume, $productInfo) {
 
 //Function for generating the <select> elements in the web ui
 function printSelections($selected, $productinfo) {
+    $optionscontent = " <option value = \"0\" >= None =</option>";
+    if (!isset($productinfo) || !sizeof($productinfo))
+        return $optionscontent;
 
     $selections = array();
     foreach ($productinfo as $product) {
         $selections[$product["id"]] = $product["name"];
     }
-    natcasesort($selections);
 
-    $optionscontent = " <option value = \"0\" >= None =</option>";
+    natcasesort($selections);
     foreach ($selections as $key => $val) {
         if ($key != $selected) {
             $optionscontent = $optionscontent . "<option value=\"" . $key . "\">" . $val . "</option>";
@@ -463,6 +465,7 @@ function printSelections($selected, $productinfo) {
             $optionscontent = $optionscontent . "<option value=\"" . $key . "\" selected >" . $val . "</option>";
         }
     }
+
     return $optionscontent;
 }
 

--- a/incl/uiEditor.inc.php
+++ b/incl/uiEditor.inc.php
@@ -17,26 +17,18 @@
 
 require_once __DIR__ . "/configProcessing.inc.php";
 
-class ButtonBuilder {
-    private $name = null;
-    private $id = null;
-    private $label = null;
-    private $editorUi = null;
-    private $onClick = null;
-    private $isRaised = false;
-    private $isHidden = false;
-    private $isColoured = false;
-    private $isDisabled = false;
-    private $additionalClasses = null;
-    private $isSubmit = false;
-    private $value = null;
-    private $isAccent = false;
+class ElementBuilder {
+    protected $name = null;
+    protected $id = null;
+    protected $label = null;
+    protected $value = null;
+    protected $editorUi = null;
+    protected $spaced = false;
 
-
-    function __construct($name, $label, $editorUi) {
+    function __construct($name, $label, $value, $editorUi) {
         $this->name     = $name;
-        $this->id       = $name;
         $this->label    = $label;
+        $this->value    = $value;
         $this->editorUi = $editorUi;
     }
 
@@ -44,6 +36,38 @@ class ButtonBuilder {
         $this->id = $id;
         return $this;
     }
+
+    function addSpaces() {
+        $this->spaced = true;
+        return $this;
+    }
+
+    function generate($asHtml = false) {
+        /** @noinspection PhpVoidFunctionResultUsedInspection */
+        $result = $this->generateInternal();
+        if ($asHtml) {
+            return $result;
+        }
+
+        $this->editorUi->addHtml($result);
+        $this->spaced && $this->editorUi->addSpaces();
+        return $this->editorUi;
+    }
+
+    protected function generateInternal() {
+        throw new Exception('generate needs to be overridden!');
+    }
+}
+
+class ButtonBuilder extends ElementBuilder {
+    private $onClick = null;
+    private $isRaised = false;
+    private $isHidden = false;
+    private $isColoured = false;
+    private $isDisabled = false;
+    private $additionalClasses = null;
+    private $isSubmit = false;
+    private $isAccent = false;
 
     function setOnClick($onClick) {
         $this->onClick = $onClick;
@@ -91,14 +115,13 @@ class ButtonBuilder {
         return $this;
     }
 
-
-    function generate($asHtml = false) {
+    protected function generateInternal() {
         return $this->editorUi->addButton($this->name,
             $this->label,
             $this->onClick,
             $this->isRaised,
             $this->isHidden,
-            $asHtml,
+            true,
             $this->isColoured,
             $this->isDisabled,
             $this->additionalClasses,
@@ -107,18 +130,43 @@ class ButtonBuilder {
             $this->value,
             $this->isAccent);
     }
+}
 
+class CheckBoxBuilder extends ElementBuilder {
+    private $isDisabled = false;
+    private $useSpaces = true;
+    private $onChanged = null;
+
+    function disabled($disabled) {
+        $this->isDisabled = $disabled;
+        return $this;
+    }
+
+    function useSpaces($useSpaces) {
+        $this->useSpaces = $useSpaces;
+        return $this;
+    }
+
+    function onCheckChanged($onCheckChanged) {
+        $this->onChanged = $onCheckChanged;
+        return $this;
+    }
+
+    protected function generateInternal()
+    {
+        return $this->editorUi->addCheckBoxInternal(
+            $this->name,
+            $this->label,
+            $this->value,
+            $this->isDisabled,
+            $this->useSpaces,
+            $this->onChanged,
+            true);
+    }
 }
 
 
-class EditFieldBuilder {
-    //required
-    private $name = null;
-    private $label = null;
-    private $value = null;
-    private $editorUi = null;
-
-    //optional
+class EditFieldBuilder extends ElementBuilder {
     private $pattern = null;
     private $type = "text";
     private $disabled = false;
@@ -137,14 +185,6 @@ class EditFieldBuilder {
     private $placeHolder = null;
     private $onKeyPress = null;
     private $width = null;
-
-
-    function __construct($name, $label, $value, $editorUi) {
-        $this->name     = $name;
-        $this->label    = $label;
-        $this->value    = $value;
-        $this->editorUi = $editorUi;
-    }
 
     function pattern($pattern) {
         $this->pattern = $pattern;
@@ -248,9 +288,16 @@ class EditFieldBuilder {
         return $this;
     }
 
-    function generate($asHtml = false) {
-        return $this->editorUi->addEditFieldInternal($this->name, $this->label, $this->value, $this->pattern, $this->type, $this->disabled, $this->autocompleteEntries, $this->autocompleteEntriesLinked, $this->autocompleteRunAjax, $this->required, $this->minmax, $this->maxlength, $this->minlength, $this->capitalize, $this->onfocusout, $this->isTimeInput, $this->onkeyup,
-            $this->floatingLabel, $this->placeHolder, $this->onKeyPress, $this->width, $asHtml);
+    protected function generateInternal()
+    {
+        return $this->editorUi->addEditFieldInternal(
+            $this->name, $this->label, $this->value, $this->pattern,
+            $this->type, $this->disabled, $this->autocompleteEntries,
+            $this->autocompleteEntriesLinked, $this->autocompleteRunAjax,
+            $this->required, $this->minmax, $this->maxlength, $this->minlength,
+            $this->capitalize, $this->onfocusout, $this->isTimeInput,
+            $this->onkeyup, $this->floatingLabel, $this->placeHolder, $this->onKeyPress,
+            $this->width, true);
     }
 
 }
@@ -328,6 +375,34 @@ class UiEditor {
 
     function addTableClass($table) {
         $this->addHtml($table->getHtml());
+    }
+
+    function addCheckBoxInternal(
+            $name,
+            $label,
+            $value,
+            $isDisabled = false,
+            $useSpaces = true,
+            $onChanged = "",
+            $asHtml = false) {
+        $html = '<label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect" for="' . $name . '">
+                  <input type="checkbox" 
+                         value="1" 
+                         id="' . $name . '" 
+                         name="' . $name . '" 
+                         onchange="' . $onChanged . '"
+                         class="mdl-checkbox__input" ' . ($isDisabled && "disabled") . ' ' . ($value && "checked") . '>
+                  <span class="mdl-checkbox__label">' . $label . '</span>
+                </label><input type="hidden" value="0" name="' . $name . '_hidden"/>';
+
+        if ($asHtml) {
+            return $html;
+        }
+
+        $this->addHtml($html);
+        $useSpaces && $this->addSpaces();
+
+        return $this;
     }
 
     function addEditFieldInternal($name, $label, $value, $pattern = null, $type = "text", $disabled = false, $autocompleteEntries = null, $autocompleteEntriesLinked = null,

--- a/incl/uiEditor.inc.php
+++ b/incl/uiEditor.inc.php
@@ -32,8 +32,8 @@ class ElementBuilder {
         $this->editorUi = $editorUi;
     }
 
-    function addScript($script) {
-        if (!$script) {
+    function addScript(?string $script) {
+        if (!empty($script)) {
             return $this;
         }
         array_push($this->scripts, $script);

--- a/incl/uiEditor.inc.php
+++ b/incl/uiEditor.inc.php
@@ -46,7 +46,6 @@ class ElementBuilder {
     }
 
     function generate($asHtml = false) {
-        /** @noinspection PhpVoidFunctionResultUsedInspection */
         $result = $this->generateInternal() . $this->generateScript();
         if ($asHtml) {
             return $result;
@@ -142,7 +141,7 @@ class ButtonBuilder extends ElementBuilder {
             $this->isColoured,
             $this->isDisabled,
             $this->additionalClasses,
-            $this->id,
+            null,
             $this->isSubmit,
             $this->value,
             $this->isAccent);
@@ -389,7 +388,7 @@ class UiEditor {
     }
 
     function buildButton($name, $label) {
-        $editor = new ButtonBuilder($name, $label, $this);
+        $editor = new ButtonBuilder($name, $label, null, $this);
         return $editor;
     }
 
@@ -505,6 +504,7 @@ class UiEditor {
         } else {
             $this->addHtml($result);
             $this->addSpaces();
+            return $this;
         }
     }
 
@@ -512,9 +512,10 @@ class UiEditor {
         $html = '<input type="hidden" id="' . $name . '" value="' . $value . '" name="' . $name . '"/>';
         if ($asHtml) {
             return $html;
-        } else {
-            $this->addHtml($html);
         }
+
+        $this->addHtml($html);
+        return $this;
     }
 
     function addSelectBox($name, $label, $valueLabels, $values = null, $preselected = null) { //TODO disabled
@@ -526,7 +527,7 @@ class UiEditor {
                     <input id="' . $name . '_value" type="hidden" value="" name="' . $name . '">
                     <i class="mdl-icon-toggle__label material-icons">keyboard_arrow_down</i>
                     <label for="' . $name . '" class="mdl-textfield__label">' . $label . '</label>
-                    <ul for="' . $name . '" class="mdl-menu mdl-menu--bottom-left mdl-js-menu">');
+                    <ul class="mdl-menu mdl-menu--bottom-left mdl-js-menu">');
         for ($i = 0; $i < count($values); $i++) {
             $preHtml = "";
             if ($preselected !== null && $i == $preselected) {
@@ -546,10 +547,10 @@ class UiEditor {
                     </label>';
         if ($asHtml) {
             return $result;
-        } else {
-            $this->addHtml($result);
-            $this->addSpaces();
         }
+        $this->addHtml($result);
+        $this->addSpaces();
+        return $this;
     }
 
     function addCheckbox($name, $label, $isChecked, $isDisabled = false, $useSpaces = true) {
@@ -590,10 +591,10 @@ class UiEditor {
         $result = '<button class="fullWidth mdl-button ' . $isColouredHtml . ' ' . $raisedHtml . ' mdl-js-button mdl-js-ripple-effect" ' . $onclickHtml . ' type="submit" name="' . $name . '" id="' . $name . '" ' . $valueHtml . '>' . $label . '</button>';
         if ($asHtml) {
             return $result;
-        } else {
-            $this->addHtml($result);
-            $this->addSpaces();
         }
+        $this->addHtml($result);
+        $this->addSpaces();
+        return $this;
     }
 
     function addDiv($htmlToDiv, $id = null, $class = null) {
@@ -661,10 +662,10 @@ class UiEditor {
 
         if ($asHtml) {
             return $result;
-        } else {
-            $this->addHtml($result);
-            $this->addSpaces();
         }
+        $this->addHtml($result);
+        $this->addSpaces();
+        return $result;
     }
 
     function addErrorMessage($id, $label, $hint) {
@@ -695,10 +696,10 @@ class UiEditor {
                 </label>';
         if ($returnAsHtml) {
             return $html;
-        } else {
-            $this->addHtml($html);
-            $this->addSpaces();
         }
+        $this->addHtml($html);
+        $this->addSpaces();
+        return $this;
     }
 
     function addLineBreak($count = 1) {

--- a/incl/uiEditor.inc.php
+++ b/incl/uiEditor.inc.php
@@ -84,6 +84,12 @@ class ButtonBuilder extends ElementBuilder {
     private $additionalClasses = null;
     private $isSubmit = false;
     private $isAccent = false;
+    private $id = null;
+
+    function setId($id) {
+        $this->id = $id;
+        return $this;
+    }
 
     function setOnClick($onClick) {
         $this->onClick = $onClick;
@@ -141,7 +147,7 @@ class ButtonBuilder extends ElementBuilder {
             $this->isColoured,
             $this->isDisabled,
             $this->additionalClasses,
-            null,
+            $this->id,
             $this->isSubmit,
             $this->value,
             $this->isAccent);

--- a/menu/settings.php
+++ b/menu/settings.php
@@ -130,13 +130,38 @@ function getHtmlSettingsBarcodeLookup() {
     $html->addLineBreak();
     $html->addCheckbox('LOOKUP_USE_JUMBO', 'Use Jumbo.com', $config["LOOKUP_USE_JUMBO"]);
     $html->addLineBreak();;
-    $html->addCheckbox(
-        "LOOKUP_USE_UPC_DATABASE",
-        "Use UPC Database",
-        $config["LOOKUP_USE_UPC_DATABASE"]);
-    $html->buildEditField('LOOKUP_UPC_DATABASE_KEY', 'UPC Database API Key', $config["LOOKUP_UPC_DATABASE_KEY"])
-        ->pattern('[A-Za-z0-9]{50}')
-        ->generate();
+    $html->addHtml(
+        (
+        new CheckBoxBuilder(
+            "LOOKUP_USE_UPC_DATABASE",
+            "Use UPC Database",
+            $config["LOOKUP_USE_UPC_DATABASE"],
+            $html)
+        )
+            ->onCheckChanged(
+            "handleUPCDBChange(this)",
+            "function handleUPCDBChange(element) {
+                api_key_input = document.querySelector('#LOOKUP_UPC_DATABASE_KEY');
+                if (!api_key_input) {
+                    console.warn('Unable to fine element LOOKUP_UPC_DATABASE_KEY');
+                } else {
+                    api_key_input.required = element.checked;
+                }
+            }")
+            ->addSpaces()
+            ->generate(true)
+    );
+    $html->addHtml(
+        (new EditFieldBuilder(
+            'LOOKUP_UPC_DATABASE_KEY',
+            'UPC Database API Key',
+            $config["LOOKUP_UPC_DATABASE_KEY"],
+            $html)
+        )
+            ->required($config["LOOKUP_USE_UPC_DATABASE"])
+            ->pattern('[A-Za-z0-9]{32}')
+            ->generate(true)
+    );
 
     return $html->getHtml();
 }

--- a/menu/settings.php
+++ b/menu/settings.php
@@ -143,7 +143,7 @@ function getHtmlSettingsBarcodeLookup() {
             "function handleUPCDBChange(element) {
                 api_key_input = document.querySelector('#LOOKUP_UPC_DATABASE_KEY');
                 if (!api_key_input) {
-                    console.warn('Unable to fine element LOOKUP_UPC_DATABASE_KEY');
+                    console.warn('Unable to find element LOOKUP_UPC_DATABASE_KEY');
                 } else {
                     api_key_input.required = element.checked;
                 }

--- a/menu/settings.php
+++ b/menu/settings.php
@@ -129,6 +129,15 @@ function getHtmlSettingsBarcodeLookup() {
     $html->addCheckbox('LOOKUP_USE_UPC', 'Use UPCitemDB.com', $config["LOOKUP_USE_UPC"]);
     $html->addLineBreak();
     $html->addCheckbox('LOOKUP_USE_JUMBO', 'Use Jumbo.com', $config["LOOKUP_USE_JUMBO"]);
+    $html->addLineBreak();;
+    $html->addCheckbox(
+        "LOOKUP_USE_UPC_DATABASE",
+        "Use UPC Database",
+        $config["LOOKUP_USE_UPC_DATABASE"]);
+    $html->buildEditField('LOOKUP_UPC_DATABASE_KEY', 'UPC Database API Key', $config["LOOKUP_UPC_DATABASE_KEY"])
+        ->pattern('[A-Za-z0-9]{50}')
+        ->generate();
+
     return $html->getHtml();
 }
 


### PR DESCRIPTION
**Purpose**
As more `lookupProviders` are added, the `if/else` approach becomes unwieldy. This PR facilitates addition of new `lookupProviders` by simply adding them to the loop. In addition, `upcdatabase.org` was added as an example of a `lookupProvider` that requires an API key and the `uiEditor` was modified to provide responsive validation, i.e. If checkbox is checked, make the APIKey required and visa-versa.

**Notes**
A little bit of scope creep from my original intention, I abstracted out an ElementBuilder for building HTML elements and added some functionality for adding element-specific scripts easily.

This PR is prep work for the larger task of addressing https://github.com/Forceu/barcodebuddy/issues/76