### PR TITLE
Add Add/Consume all buttons

### DIFF
--- a/index.php
+++ b/index.php
@@ -372,6 +372,8 @@ function getHtmlMainMenuTableKnown(array $barcodes): string {
         if ($containsFederationName)
             array_splice($arrayTableEntries, 1, 0, array("Federation"));
 
+        addModifyAllButtons($html);
+
         $table = new TableGenerator($arrayTableEntries);
         foreach ($barcodes['known'] as $item) {
             $isDisabled = "disabled";
@@ -444,18 +446,7 @@ function getHtmlMainMenuTableUnknown(array $barcodes): string {
         $html->addHtml("No unknown barcodes yet.");
         return $html->getHtml();
     } else {
-        $html->addHtml($html->buildButton("button_add_all", "Add all")
-                ->setSubmit()
-                ->setRaised()
-                ->setIsAccent()
-                ->setId('button_add_all')
-                ->generate(true));
-        $html->addHtml($html->buildButton("button_consume_all", "Consume all")
-            ->setSubmit()
-            ->setRaised()
-            ->setIsAccent()
-            ->setId('button_consume_all')
-            ->generate(true));
+        addModifyAllButtons($html);
         $table = new TableGenerator(array(
             "Barcode",
             "Look up",
@@ -501,6 +492,24 @@ function getHtmlMainMenuTableUnknown(array $barcodes): string {
         $html->addTableClass($table);
         return $html->getHtml();
     }
+}
+
+
+function addModifyAllButtons($html) {
+    $html->addHtml('<div class="mdl-cell">');
+    $html->addHtml($html->buildButton("button_add_all", "Add all")
+        ->setSubmit()
+        ->setRaised()
+        ->setIsAccent()
+        ->setId('button_add_all')
+        ->generate(true));
+    $html->addHtml($html->buildButton("button_consume_all", "Consume all")
+        ->setSubmit()
+        ->setRaised()
+        ->setIsAccent()
+        ->setId('button_consume_all')
+        ->generate(true));
+    $html->addHtml('</div>');
 }
 
 

--- a/index.php
+++ b/index.php
@@ -212,8 +212,8 @@ function processButtons() {
 
     if (isset($_POST["button_add_all"]) || isset($_POST["button_consume_all"])) {
         $isConsume = isset($_POST["button_consume_all"]);
-        $selectValues = array_filter($_POST, function($key, $value) {
-            return strpos($value, 'select_') !== false;
+        $selectValues = array_filter($_POST, function($value, $key) {
+            return strpos($key, 'select_') !== false && $value !== 0;
         }, ARRAY_FILTER_USE_BOTH);
 
         foreach ($selectValues as $key => $value) {


### PR DESCRIPTION
Hi there,

I've been wanting to add those for a while now. When there's at least one product in the list of known/unknown barcodes, the UI will display additional buttons to add or consume all products that have been assigned a Grocy id. This allows me to quickly assign products without having to click the regular Add/Consume buttons all the time and waiting for the page to reload.

I've added a check to only update products that have anything other than == None == selected in the product field.

Let me know what you think (or if there's anything I should do differently UI-wise). Also let me know if this feature already exists and I'm just too dumb to use it ;)

Cheers
Philipp