### PR TITLE
Add KEY_KPMINUS support

### DIFF
--- a/example/grabInput.py
+++ b/example/grabInput.py
@@ -71,7 +71,8 @@ CODE_MAP_CHAR = {
     'KEY_Y': "Y",
     'KEY_Z': "Z",
     'KEY_DOT': ".",
-    'KEY_MINUS': "-"
+    'KEY_MINUS': "-",
+    'KEY_KPMINUS': "-"
 
 }
 

--- a/example/grabInput.sh
+++ b/example/grabInput.sh
@@ -82,6 +82,7 @@ declare -A CODE_MAP_CHAR=( ["(KEY_0)"]="0" \
     ["(KEY_DOT)"]="." \
     ["(KEY_KPDOT)"]="." \
     ["(KEY_MINUS)"]="-" \
+    ["(KEY_KPMINUS)"]="-" \
     ["(KEY_SLASH)"]="-" \
     ["(KEY_ENTER)"]="KEY_ENTER" \
     ["(KEY_KPENTER)"]="KEY_ENTER" )


### PR DESCRIPTION
My barcode scanner (Nadamoo Bur3069-2D) uses the keypad
minus button for - instead of the typical regular minus.