### PR TITLE
Added support for fullscreen on iOS devices

### DIFF
--- a/screen.php
+++ b/screen.php
@@ -45,6 +45,7 @@ $CONFIG->checkIfAuthenticated(true);
     <meta name="msapplication-navbutton-color" content="#ccc">
     <meta name="msapplication-TileColor" content="#ccc">
     <meta name="apple-mobile-web-app-status-bar-style" content="#ccc">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="theme-color" content="#ccc">
 
 


### PR DESCRIPTION
I wanted to add barcode buddy as a separate "App" on the homescreen of my iPad. By doing this, I realized that the Safari toolbar is still visible. To hide the toolbar if the page is added to the homescreen, an additional meta tag has to be added.