### PR TITLE
prefer BASEURL in getApiUrl

### DIFF
--- a/incl/processing.inc.php
+++ b/incl/processing.inc.php
@@ -729,6 +729,10 @@ function generateRandomString(int $length = 30): string {
 }
 
 function getApiUrl(string $removeAfter): string {
+    $baseurl = BBConfig::getInstance()["BASEURL"];
+    if ($baseurl && preg_match('/^https?:\/\//',$baseurl)) {
+        return preg_replace("/\/+$/", '', $baseurl) . "/api/";
+    }
     $protocol = ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
 
     $url = $protocol . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];


### PR DESCRIPTION
This patch should fix the problem that "Add mobile app" is showing the "calculated" URL using '$_SERVER' variables but ignoring 'BASEURL' from the config.php.

Without this patch, systems behind a reverse proxy are exposing their internal settings and do not generate a URL containing the "official" domain/url