### PR TITLE
Fix AH invalid refresh token handling

### DIFF
--- a/incl/lookupProviders/ProviderAlbertHeijn.php
+++ b/incl/lookupProviders/ProviderAlbertHeijn.php
@@ -97,17 +97,15 @@ class ProviderAlbertHeijn extends LookupProvider {
     private function refreshToken(string $refreshToken): ?array {
         $json            = '{"clientId": "appie", "refreshToken": "' . $refreshToken . '"}';
         $url             = "https://api.ah.nl/mobile-auth/v1/auth/token/refresh";
-        $authkeyResponse = null;
-        
-        try {
-            $authkeyResponse = $this->execute($url, METHOD_POST, null, self::USER_AGENT, null, true, $json);
-        }
-        catch(Exception $e) {
+        $authkeyResponse = $this->execute($url, METHOD_POST, null, self::USER_AGENT, null, true, $json);
+
+        if ($authkeyResponse == null) {
             $authkeyResponse = $this->newAuthToken();
         }
-    
-        if (!isset($authkeyResponse["access_token"]))
+
+        if (!isset($authkeyResponse["access_token"])) {
             return null;
+        }
 
         return $authkeyResponse;
     }


### PR DESCRIPTION
Hi there, again 😅 

Back with another small fix.
The invalid refresh token handling was wrong for the AH provider.

I placed it inside a try-catch, not knowing the `$this->execute` is already wrapped in a try-catch with a `return null` fallback. So the AH provider never went in the catch, where the handling should've happen.