### PR TITLE
Quantity unit conversions

### DIFF
--- a/incl/modules/barcodeFederation.php
+++ b/incl/modules/barcodeFederation.php
@@ -68,9 +68,11 @@ class BarcodeFederation {
         $items = array();
 
         foreach ($barcodes as $barcode) {
-            $name = $products[$barcode["id"]]->name;
-            if (strlen($name) > 1 && strlen($barcode["barcode"]) > 4)
-                array_push($items, new ServerBarcode($barcode, $name));
+            if (!($barcode instanceof GrocyProductBarcode))
+                continue;
+            $name = $products[$barcode->productId]->name;
+            if (strlen($name) > 1 && strlen($barcode->barcode) > 4)
+                array_push($items, new ServerBarcode($barcode->barcode, $name));
         }
         $json = json_encode(array("ServerBarcodes" => $items));
         try {
@@ -253,16 +255,16 @@ class BarcodeFederation {
 }
 
 class ServerBarcode {
-    public $name;
-    public $barcode;
+    public string $name;
+    public string $barcode;
 
     /**
      * BarcodeServerItem constructor.
      * @param array $barcode
      * @param string $name
      */
-    public function __construct(array $barcode, string $name) {
+    public function __construct(string $barcode, string $name) {
         $this->name    = $name;
-        $this->barcode = $barcode["barcode"];
+        $this->barcode = $barcode;
     }
 }

--- a/index.php
+++ b/index.php
@@ -255,7 +255,7 @@ function processButtons(): void {
                             $amount = $product->stockAmount;
                         if ($amount > 0) {
                             API::consumeProduct($gidSelected, $amount);
-                            $log = new LogOutput("Consuming $amount " . $product->unit . " of " . $product->name, EVENT_TYPE_ADD_KNOWN_BARCODE);
+                            $log = new LogOutput("Consuming $amount " . $product->unit->name . " of " . $product->name, EVENT_TYPE_ADD_KNOWN_BARCODE);
                         } else {
                             $log = new LogOutput("None in stock, not consuming: " . $product->name, EVENT_TYPE_ADD_KNOWN_BARCODE);
                         }
@@ -265,7 +265,7 @@ function processButtons(): void {
                         if (!API::purchaseProduct($gidSelected, $amount, $row["bestBeforeInDays"], $row["price"])) {
                             $additionalLog = " [WARNING]: No default best before date set!";
                         }
-                        $log = new LogOutput("Adding $amount " . $product->unit . " of " . $product->name . $additionalLog, EVENT_TYPE_ADD_KNOWN_BARCODE);
+                        $log = new LogOutput("Adding $amount " . $product->unit->name . " of " . $product->name . $additionalLog, EVENT_TYPE_ADD_KNOWN_BARCODE);
                         $log->setVerbose()->dontSendWebsocket()->createLog();
                     }
                 }


### PR DESCRIPTION
This is just a rough attempt at using the amount and quantity configured in grocy's product barcode for purchase and consume amounts. This likely relates to #209/#161/#123. Adding a config toggle that uses the default consume/purchase quantity+amount instead of the barcode's would probably make sense to address #215 as well.