### PR TITLE
Register barcode in Grocy after creating product via "Create Product"

### DIFF
--- a/incl/processing.inc.php
+++ b/incl/processing.inc.php
@@ -329,6 +329,9 @@ function processRefreshedBarcode(string $barcode): void {
     $productInfo = API::getLastCreatedProduct(5);
     if ($productInfo != null) {
         DatabaseConnection::getInstance()->updateSavedBarcodeMatch($barcode, $productInfo->id);
+        API::addBarcode($productInfo->id, $barcode, null);
+        $log = new LogOutput("Associated barcode $barcode with " . $productInfo->name, EVENT_TYPE_ASSOCIATE_PRODUCT);
+        $log->setVerbose()->dontSendWebsocket()->createLog();
     }
 }
 


### PR DESCRIPTION
## Summary
When the user clicks **Create Product** on an unknown barcode in BB, BB opens Grocy's new-product page in a new tab with the OpenFoodFacts-derived name prefilled. After the Grocy tab closes, BB's `processRefreshedBarcode()` updates the local `Barcodes` table to point the scanned barcode at the just-created Grocy product — but it never registers the barcode against the product in Grocy itself.

The barcode only ends up in Grocy if the user *also* clicks **Add** or **Consume** in BB, which routes through `API::addBarcode()`. Reasonable users expect "Create Product" to fully integrate the new product, including the barcode, in a single action.

This adds the `API::addBarcode()` call inside `processRefreshedBarcode()`, immediately after the local-match update, plus the corresponding `EVENT_TYPE_ASSOCIATE_PRODUCT` log entry to match the existing pattern in `index.php`.

## Side note
Subsequent **Add**/**Consume** clicks for the same row will still call `API::addBarcode()` (now a duplicate). Grocy returns an error which `API::processError()` already swallows, so the inventory action proceeds; the only effect is a stray "Could not set Grocy barcode" log line and a slightly misleading "Associated barcode" log entry. A nice follow-up would be to guard the `index.php` `addBarcode` call with a known-barcode check, but I've kept this PR focused on the user-facing bug.

## Test plan
- [x] Scan an unknown barcode in BB
- [x] Click **Create Product** → Grocy opens → create the product → close tab
- [x] Confirm Grocy product master data now shows the barcode (previously empty)
- [x] Confirm BB log shows "Associated barcode X with <product>" entry
- [x] Verify behaviour when no product is created within the 5s window (existing condition `$productInfo != null` should preserve the current behaviour)